### PR TITLE
Added vcf-rename to rename samples in VCF files

### DIFF
--- a/src/java/io/compgen/ngsutils/NGSUtils.java
+++ b/src/java/io/compgen/ngsutils/NGSUtils.java
@@ -100,6 +100,7 @@ import io.compgen.ngsutils.cli.vcf.VCFToBED;
 import io.compgen.ngsutils.cli.vcf.VCFToBEDPE;
 import io.compgen.ngsutils.cli.vcf.VCFToCount;
 import io.compgen.ngsutils.cli.vcf.VCFPeptide;
+import io.compgen.ngsutils.cli.vcf.VCFRenameSample;
 import io.compgen.ngsutils.cli.vcf.VCFConsensus;
 import io.compgen.ngsutils.cli.vcf.VCFTsTvRatio;
 import io.compgen.ngsutils.support.DigestCmd;
@@ -224,7 +225,8 @@ public class NGSUtils {
 			.addCommand(TabJoin.class)
 			.addCommand(FastaBins.class)
 			.addCommand(VCFBedCount.class)
-			.addCommand(VCFConsensus.class);
+			.addCommand(VCFConsensus.class)
+			.addCommand(VCFRenameSample.class);
 
         try {
             if (args.length == 0) {

--- a/src/java/io/compgen/ngsutils/cli/vcf/VCFRenameSample.java
+++ b/src/java/io/compgen/ngsutils/cli/vcf/VCFRenameSample.java
@@ -1,0 +1,76 @@
+package io.compgen.ngsutils.cli.vcf;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.compgen.cmdline.annotation.Command;
+import io.compgen.cmdline.annotation.Exec;
+import io.compgen.cmdline.annotation.Option;
+import io.compgen.cmdline.annotation.UnnamedArg;
+import io.compgen.cmdline.exceptions.CommandArgumentException;
+import io.compgen.cmdline.impl.AbstractOutputCommand;
+import io.compgen.common.IterUtils;
+import io.compgen.ngsutils.NGSUtils;
+import io.compgen.ngsutils.vcf.VCFHeader;
+import io.compgen.ngsutils.vcf.VCFReader;
+import io.compgen.ngsutils.vcf.VCFRecord;
+import io.compgen.ngsutils.vcf.VCFWriter;
+
+
+@Command(name="vcf-rename", desc="Change the names of samples", category="vcf")
+public class VCFRenameSample extends AbstractOutputCommand {
+	private String filename = "-";
+    
+	private List<String> oldNames = new ArrayList<String>();
+	private List<String> newNames = new ArrayList<String>();
+	
+	
+    @UnnamedArg(name = "input.vcf", required=true)
+    public void setFilename(String filename) throws CommandArgumentException {
+    	this.filename = filename;
+    }
+
+    @Option(desc="Sample to rename (colon delimited: NAME:NEWNAME, can use sample number for NAME)", name="sample", allowMultiple=true)
+    public void setSample(String val) throws CommandArgumentException {
+    	String[] spl = val.split(":");
+    	if (spl.length != 2) {
+    		throw new CommandArgumentException("Invalid option for --sample: " + val);
+    	}
+    	oldNames.add(spl[0]);
+    	newNames.add(spl[1]);
+    }
+
+	@Exec
+	public void exec() throws Exception {
+    	if (oldNames.size() ==0 ) {
+    		throw new CommandArgumentException("You must specify at least one sample to rename!");
+    	}
+
+		VCFReader reader = new VCFReader(filename);
+		
+		VCFHeader header = reader.getHeader();
+		header.addLine("##ngsutilsj_vcf_renameCommand="+NGSUtils.getArgs());
+		if (!header.contains("##ngsutilsj_vcf_renameVersion="+NGSUtils.getVersion())) {
+		    header.addLine("##ngsutilsj_vcf_renameVersion="+NGSUtils.getVersion());
+		}
+
+		for (int i=0; i<oldNames.size(); i++) {
+			header.renameSample(oldNames.get(i), newNames.get(i));
+		}
+		
+		VCFWriter writer = new VCFWriter(out, header);
+//		VCFWriter writer;
+//		if (out.equals("-")) {
+//			writer = new VCFWriter(System.out, header);
+//		} else {
+//			writer = new VCFWriter(out, header);
+//		}
+
+		for (VCFRecord rec: IterUtils.wrap(reader.iterator())) {
+
+            writer.write(rec);
+		}		
+		reader.close();
+		writer.close();
+	}
+}

--- a/src/java/io/compgen/ngsutils/vcf/VCFHeader.java
+++ b/src/java/io/compgen/ngsutils/vcf/VCFHeader.java
@@ -207,6 +207,15 @@ public class VCFHeader {
 		return Collections.unmodifiableList(this.samples);
 	}
 	
+	public void renameSample(String oldname, String newname) throws VCFParseException {
+		int idx = getSamplePosByName(oldname);
+		if (idx > -1) {
+			samples.set(idx, newname);
+		} else {
+			throw new VCFParseException("Couldn't find sample: "+oldname);
+		}
+	}
+	
 	/**
 	 * Line should include the "##" prefix
 	 * @param line


### PR DESCRIPTION
This is handy if you need to merge files, but one has the samples named
Sample1 Sample2, but the other has TUMOR NORMAL

This does not re-order samples.