### PR TITLE
Fix VCF format field truncation 

### DIFF
--- a/src/java/io/compgen/ngsutils/vcf/VCFAttributes.java
+++ b/src/java/io/compgen/ngsutils/vcf/VCFAttributes.java
@@ -84,7 +84,7 @@ public class VCFAttributes {
 		return attrs;
 	}
 	
-	public static VCFAttributes parseFormat(String s, List<String> format, VCFHeader header) throws VCFParseException, VCFAttributeException {
+	public static VCFAttributes parseFormat(String s, List<String> formatKeys, VCFHeader header) throws VCFParseException, VCFAttributeException {
 		VCFAttributes attrs = new VCFAttributes();
 		
 		String[] spl = s.split(":");
@@ -95,13 +95,13 @@ public class VCFAttributes {
 //		}
 
 		// if GT is present in {format}, it must be in the input string for each sample.
-		if (format != null && format.size() > 0 && format.get(0).equals("GT") && spl.length<1) {
+		if (formatKeys != null && formatKeys.size() > 0 && formatKeys.get(0).equals("GT") && spl.length<1) {
 			throw new VCFParseException("Unable to parse genotype field: "+s);
 		}
 		
 		for (int i=0; i< spl.length; i++) {
-		    if (header == null || header.isFormatAllowed(format.get(i))) {
-		        attrs.put(format.get(i), VCFAttributeValue.parse(spl[i]));
+		    if (header == null || header.isFormatAllowed(formatKeys.get(i))) {
+		        attrs.put(formatKeys.get(i), VCFAttributeValue.parse(spl[i]));
 		    }
 		}
 		return attrs;

--- a/src/java/io/compgen/ngsutils/vcf/VCFRecord.java
+++ b/src/java/io/compgen/ngsutils/vcf/VCFRecord.java
@@ -199,12 +199,6 @@ public class VCFRecord {
         }
         
 		if (sampleAttributes != null && sampleAttributes.size() > 0) {
-
-			// TODO: BUGFIX: If the first sample is missing a value for a key, it will be removed for all other samples.
-			//       Example, if the FORMAT field is AA:BB:CC and the first sample only has values for AA:BB, then any
-			//       other samples with CC will be truncated.
-			//
-
 			if (formatKeys != null && formatKeys.size() > 0) {
 				// Write FORMAT
 	            outcols.add(StringUtils.join(":", formatKeys));

--- a/src/java/io/compgen/ngsutils/vcf/VCFRecord.java
+++ b/src/java/io/compgen/ngsutils/vcf/VCFRecord.java
@@ -128,6 +128,7 @@ public class VCFRecord {
 	protected List<String> filters = null;
 
 	protected VCFAttributes info = null;
+	protected List<String> formatKeys = null;
 	protected List<VCFAttributes> sampleAttributes = null;
 
 	protected VCFHeader parentHeader = null;
@@ -139,7 +140,7 @@ public class VCFRecord {
 	}
 	
 	public VCFRecord(String chrom, int pos, String dbSNPID, String ref, List<String> alt, double qual,
-			List<String> filters, VCFAttributes info, List<VCFAttributes> sampleAttributes, String altFull, VCFHeader header) {
+			List<String> filters, VCFAttributes info, List<String> formatKeys, List<VCFAttributes> sampleAttributes, String altFull, VCFHeader header) {
 		this.chrom = chrom;
 		this.pos = pos;
 		this.dbSNPID = dbSNPID;
@@ -150,6 +151,7 @@ public class VCFRecord {
 		this.info = info;
 		this.sampleAttributes = sampleAttributes;
 		this.altOrig = altFull;
+		this.formatKeys = formatKeys;
 		this.parentHeader = header;
 	}
 
@@ -197,10 +199,16 @@ public class VCFRecord {
         }
         
 		if (sampleAttributes != null && sampleAttributes.size() > 0) {
+
+			// TODO: BUGFIX: If the first sample is missing a value for a key, it will be removed for all other samples.
+			//       Example, if the FORMAT field is AA:BB:CC and the first sample only has values for AA:BB, then any
+			//       other samples with CC will be truncated.
+			//
+
 			List<String> keyOrder = sampleAttributes.get(0).getKeys();
-			if (keyOrder.size() > 0) {
+			if (formatKeys != null && formatKeys.size() > 0) {
 				// Write FORMAT
-	            outcols.add(StringUtils.join(":", keyOrder));
+	            outcols.add(StringUtils.join(":", formatKeys));
 				
 				// Write sample values
 				for (VCFAttributes attrs: sampleAttributes) {
@@ -271,7 +279,8 @@ public class VCFRecord {
 		}
 
 //		System.err.println("FILTER: " + cols[6] + " => " + (filters == null ? "<null>": "?"+StringUtils.join(",", filters)));
-		
+		List<String> formatKeys = null;
+
 		try {
 			List<VCFAttributes> sampleValues = null;
 			VCFAttributes info = new VCFAttributes();
@@ -283,9 +292,9 @@ public class VCFRecord {
 				
 				
 				if (cols.length>8) {
-					List<String> format = new ArrayList<String>();
+					formatKeys = new ArrayList<String>();
 					for (String k: cols[8].split(":")) {
-					        format.add(k);
+						formatKeys.add(k);
 					}
 					
 					if (cols.length>9) {
@@ -304,7 +313,7 @@ public class VCFRecord {
 									while (sampleValues.size() <= newSampleIdx) {
 										sampleValues.add(null);
 									}
-									sampleValues.set(newSampleIdx, VCFAttributes.parseFormat(cols[i], format, header));
+									sampleValues.set(newSampleIdx, VCFAttributes.parseFormat(cols[i], formatKeys, header));
 								}
 							}
 						}
@@ -312,7 +321,7 @@ public class VCFRecord {
 				}
 			}
 			
-			return new VCFRecord(chrom, pos, dbSNPID, ref, alts, qual, filters, info, sampleValues, altOrig, header);
+			return new VCFRecord(chrom, pos, dbSNPID, ref, alts, qual, filters, info, formatKeys, sampleValues, altOrig, header);
 
 		} catch (VCFParseException | VCFAttributeException e) {
 			if (!VCFCheck.isQuiet()) {

--- a/src/java/io/compgen/ngsutils/vcf/VCFRecord.java
+++ b/src/java/io/compgen/ngsutils/vcf/VCFRecord.java
@@ -205,7 +205,6 @@ public class VCFRecord {
 			//       other samples with CC will be truncated.
 			//
 
-			List<String> keyOrder = sampleAttributes.get(0).getKeys();
 			if (formatKeys != null && formatKeys.size() > 0) {
 				// Write FORMAT
 	            outcols.add(StringUtils.join(":", formatKeys));
@@ -215,7 +214,7 @@ public class VCFRecord {
 					if (attrs == null) {
 						outcols.add(".");
 					} else {
-						outcols.add(attrs.toString(keyOrder));
+						outcols.add(attrs.toString(formatKeys));
 					}
 				}
 			}


### PR DESCRIPTION
When the first VCF sample FORMAT record is missing values, the FORMAT value would be removed from all other samples. This fixes that issue. Now, the FORMAT fields are kept from the primary record, not the first sample.

Fixes #22 