### PR TITLE
format keys update -- added --dosage

### DIFF
--- a/src/java/io/compgen/ngsutils/cli/vcf/VCFAnnotateCmd.java
+++ b/src/java/io/compgen/ngsutils/cli/vcf/VCFAnnotateCmd.java
@@ -19,6 +19,7 @@ import io.compgen.ngsutils.vcf.VCFWriter;
 import io.compgen.ngsutils.vcf.annotate.BEDAnnotation;
 import io.compgen.ngsutils.vcf.annotate.ConstantTag;
 import io.compgen.ngsutils.vcf.annotate.CopyNumberLogRatio;
+import io.compgen.ngsutils.vcf.annotate.Dosage;
 import io.compgen.ngsutils.vcf.annotate.FisherStrandBias;
 import io.compgen.ngsutils.vcf.annotate.FlankingBases;
 import io.compgen.ngsutils.vcf.annotate.GTFGene;
@@ -90,6 +91,11 @@ public class VCFAnnotateCmd extends AbstractOutputCommand {
     @Option(desc="Add a TS, TV annotations (TS: A<->G, C<->T)", name="tstv")
     public void setTsTv() throws CommandArgumentException {
     	chain.add(new TransitionTransversion());
+    }
+    
+    @Option(desc="Calculate dosage values from GT", name="dosage")
+    public void setDosage() throws CommandArgumentException {
+    	chain.add(new Dosage());
     }
     
     @Option(desc="Add minor strand pct (FORMAT:CG_SBPCT, requires SAC)", name="minor-strand")

--- a/src/java/io/compgen/ngsutils/vcf/VCFAnnotationDef.java
+++ b/src/java/io/compgen/ngsutils/vcf/VCFAnnotationDef.java
@@ -46,11 +46,11 @@ public class VCFAnnotationDef {
 		
 		if (isInfo) {
 			if (!VALID_INFO_TYPE.contains(type)) {
-				throw new VCFParseException("Invalid \"Type\" value for INFO line!");
+				throw new VCFParseException("Invalid \"Type\" value for INFO line! ("+type+")");
 			}
 		} else {
 			if (!VALID_FORMAT_TYPE.contains(type)) {
-				throw new VCFParseException("Invalid \"Type\" value for FORMAT line!");
+				throw new VCFParseException("Invalid \"Type\" value for FORMAT line! ("+type+")");
 			}
 		}
 		

--- a/src/java/io/compgen/ngsutils/vcf/VCFAttributes.java
+++ b/src/java/io/compgen/ngsutils/vcf/VCFAttributes.java
@@ -99,9 +99,13 @@ public class VCFAttributes {
 			throw new VCFParseException("Unable to parse genotype field: "+s);
 		}
 		
-		for (int i=0; i< spl.length; i++) {
+		for (int i=0; i<formatKeys.size(); i++) {
 		    if (header == null || header.isFormatAllowed(formatKeys.get(i))) {
-		        attrs.put(formatKeys.get(i), VCFAttributeValue.parse(spl[i]));
+		    	if (spl.length > i) {
+		    		attrs.put(formatKeys.get(i), VCFAttributeValue.parse(spl[i]));
+		    	} else {
+		    		attrs.put(formatKeys.get(i), VCFAttributeValue.MISSING);
+		    	}
 		    }
 		}
 		return attrs;

--- a/src/java/io/compgen/ngsutils/vcf/VCFRecord.java
+++ b/src/java/io/compgen/ngsutils/vcf/VCFRecord.java
@@ -128,7 +128,7 @@ public class VCFRecord {
 	protected List<String> filters = null;
 
 	protected VCFAttributes info = null;
-	protected List<String> formatKeys = null;
+//	protected List<String> formatKeys = null;
 	protected List<VCFAttributes> sampleAttributes = null;
 
 	protected VCFHeader parentHeader = null;
@@ -140,7 +140,9 @@ public class VCFRecord {
 	}
 	
 	public VCFRecord(String chrom, int pos, String dbSNPID, String ref, List<String> alt, double qual,
-			List<String> filters, VCFAttributes info, List<String> formatKeys, List<VCFAttributes> sampleAttributes, String altFull, VCFHeader header) {
+			List<String> filters, VCFAttributes info, 
+			//List<String> formatKeys, 
+			List<VCFAttributes> sampleAttributes, String altFull, VCFHeader header) {
 		this.chrom = chrom;
 		this.pos = pos;
 		this.dbSNPID = dbSNPID;
@@ -151,7 +153,7 @@ public class VCFRecord {
 		this.info = info;
 		this.sampleAttributes = sampleAttributes;
 		this.altOrig = altFull;
-		this.formatKeys = formatKeys;
+//		this.formatKeys = formatKeys;
 		this.parentHeader = header;
 	}
 
@@ -199,19 +201,20 @@ public class VCFRecord {
         }
         
 		if (sampleAttributes != null && sampleAttributes.size() > 0) {
-			if (formatKeys != null && formatKeys.size() > 0) {
-				// Write FORMAT
-	            outcols.add(StringUtils.join(":", formatKeys));
-				
-				// Write sample values
-				for (VCFAttributes attrs: sampleAttributes) {
-					if (attrs == null) {
-						outcols.add(".");
-					} else {
-						outcols.add(attrs.toString(formatKeys));
-					}
+//			if (formatKeys != null && formatKeys.size() > 0) {
+			List<String> formatKeys = sampleAttributes.get(0).getKeys();
+			// Write FORMAT
+            outcols.add(StringUtils.join(":", formatKeys));
+			
+			// Write sample values
+			for (VCFAttributes attrs: sampleAttributes) {
+				if (attrs == null) {
+					outcols.add(".");
+				} else {
+					outcols.add(attrs.toString(formatKeys));
 				}
 			}
+			//}			
 		}
 		
 		StringUtils.writeOutputStream(out, StringUtils.join("\t", outcols)+"\n");
@@ -314,7 +317,8 @@ public class VCFRecord {
 				}
 			}
 			
-			return new VCFRecord(chrom, pos, dbSNPID, ref, alts, qual, filters, info, formatKeys, sampleValues, altOrig, header);
+//			return new VCFRecord(chrom, pos, dbSNPID, ref, alts, qual, filters, info, formatKeys, sampleValues, altOrig, header);
+			return new VCFRecord(chrom, pos, dbSNPID, ref, alts, qual, filters, info, sampleValues, altOrig, header);
 
 		} catch (VCFParseException | VCFAttributeException e) {
 			if (!VCFCheck.isQuiet()) {
@@ -703,4 +707,5 @@ public class VCFRecord {
         }
         return baos.toString();
 	}
+    
 }

--- a/src/java/io/compgen/ngsutils/vcf/annotate/Dosage.java
+++ b/src/java/io/compgen/ngsutils/vcf/annotate/Dosage.java
@@ -1,0 +1,56 @@
+package io.compgen.ngsutils.vcf.annotate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.compgen.common.StringUtils;
+import io.compgen.ngsutils.vcf.VCFAnnotationDef;
+import io.compgen.ngsutils.vcf.VCFAttributeException;
+import io.compgen.ngsutils.vcf.VCFAttributeValue;
+import io.compgen.ngsutils.vcf.VCFAttributes;
+import io.compgen.ngsutils.vcf.VCFHeader;
+import io.compgen.ngsutils.vcf.VCFParseException;
+import io.compgen.ngsutils.vcf.VCFRecord;
+
+public class Dosage extends AbstractBasicAnnotator {
+	
+
+	@Override
+	public void setHeaderInner(VCFHeader header) throws VCFAnnotatorException {
+		try {
+            header.addFormat(VCFAnnotationDef.format("CG_DS", "A", "Integer", "Convert GT to dosage value (0, 1, 2)"));
+        } catch (VCFParseException e) {
+            throw new VCFAnnotatorException(e);
+        }
+	}
+	
+	protected void annotate(VCFRecord record) throws VCFAnnotatorException {
+		for (VCFAttributes sampleVals : record.getSampleAttributes()) {
+		    if (sampleVals.contains("GT")) {
+		    	try {
+		    		List<String> dsOut = new ArrayList<String>();
+					String[] gts = sampleVals.get("GT").asString(null).split("[/\\|]");
+			    	for (int altNum = 1; altNum <= record.getAlt().size(); altNum++) {
+				    	int ds = 0;
+			    		String alt = ""+altNum;
+			    		for (String gt: gts) {
+			    			if (gt.equals(alt)) {
+			    				ds++;
+			    			}
+			    		}
+			    		dsOut.add(""+ds);
+			    	}
+			    	sampleVals.put("CG_DS", VCFAttributeValue.parse(StringUtils.join(",", dsOut)));
+				} catch (VCFAttributeException | VCFParseException e) {
+					throw new VCFAnnotatorException(e);
+				}		    	
+		    } else {
+		    	try {
+		    		sampleVals.put("CG_DS", VCFAttributeValue.MISSING);
+				} catch (VCFAttributeException e) {
+					throw new VCFAnnotatorException(e);
+				}
+		    }
+		}
+	}
+}


### PR DESCRIPTION
added --dosage to convert GT values to dosage values (0,1,2). This doesn't do anything other than look at the GT value and compare it to the alt alleles.

But, in adding this, I realized that adding a fixed formatKeys for each VCFRecord broke a number of annotations where format annotations were getting added and not updating the formatKeys.

So, I reverted back to using the first sample's keys as the canonical reference for keys we should display. But -- I also made it so that when parsing a format field, we will store empty values when appropriate. This should finally fix this issue.