### PR TITLE
cache tabix query results and document BGZF cache size #codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,5 @@ or you can use the embedded JAR version, which is a small shell script shim in f
     ./ngsutilsj
 
 Using the embedded JAR version is easier for typing at the command-line, but uses the exact same JAR file. If you use the embedded JAR version, but need to set any extra command-line parameters for java, you can use the `JAVA_OPT` environmental variable, or set `JAVA_OPT` in `$HOME/.ngsutilsjrc`. If needed, you can also set `JAVA_HOME` on the command-line or in `$HOME/.ngsutilsjrc`.
+
+BGZF cache sizing: set `-Dngsutilsj.bgzf.cache.mb=<MB>` to override the default 32 MB BGZF uncompressed block cache.

--- a/src/java/io/compgen/ngsutils/support/CachedIterator.java
+++ b/src/java/io/compgen/ngsutils/support/CachedIterator.java
@@ -1,0 +1,60 @@
+package io.compgen.ngsutils.support;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+public class CachedIterator<T> implements Iterator<T> {
+	private final Iterator<T> parent;
+	private final List<T> cache = new ArrayList<T>();
+	private int index = 0;
+	private boolean parentExhausted = false;
+	
+	public CachedIterator(Iterator<T> parent) {
+		this.parent = parent;
+	}
+	
+	@Override
+	public boolean hasNext() {
+		if (index < cache.size()) {
+			return true;
+		}
+		if (parentExhausted) {
+			return false;
+		}
+		if (parent.hasNext()) {
+			return true;
+		}
+		parentExhausted = true;
+		return false;
+	}
+	
+	@Override
+	public T next() {
+		if (index < cache.size()) {
+			return cache.get(index++);
+		}
+		if (parentExhausted || !parent.hasNext()) {
+			parentExhausted = true;
+			throw new NoSuchElementException();
+		}
+		T next = parent.next();
+		cache.add(next);
+		index++;
+		return next;
+	}
+	
+	public void reset() {
+		index = 0;
+	}
+	
+	public boolean isExhausted() {
+		return parentExhausted;
+	}
+	
+	public List<T> getCache() {
+		return Collections.unmodifiableList(cache);
+	}
+}

--- a/src/java/io/compgen/ngsutils/tabix/BGZFile.java
+++ b/src/java/io/compgen/ngsutils/tabix/BGZFile.java
@@ -39,11 +39,11 @@ public class BGZFile {
         							   // remove blocks until the size smaller than resetSize.
         
         private BGZFileCache() {
-            this(16 * 1024 * 1024, 12 * 1024 * 1024);  // 16 MB cache, 12 MB reset size 
+            this(getDefaultBGZCacheSize());
         }
 
         private BGZFileCache(long maxSize) {
-        	this(maxSize, maxSize);
+        	this(maxSize, (maxSize * 3) / 4);
         }
 
         private BGZFileCache(long maxSize, long resetSize) {
@@ -54,6 +54,8 @@ public class BGZFile {
             this.maxSize = maxSize;
             this.resetSize = resetSize;
         }
+        
+        
         
         private BGZBlock get(long cPos) {
             if (!blockCache.containsKey(cPos)) {
@@ -140,6 +142,22 @@ public class BGZFile {
     
     public FileChannel getChannel() { 
         return file.getChannel();
+    }
+
+    private static long getDefaultBGZCacheSize() {
+        String prop = System.getProperty("ngsutilsj.bgzf.cache.mb");
+        long mb = 32;
+        if (prop != null && !prop.equals("")) {
+            try {
+                mb = Long.parseLong(prop);
+            } catch (NumberFormatException e) {
+                mb = 32;
+            }
+        }
+        if (mb < 1) {
+            mb = 1;
+        }
+        return mb * 1024 * 1024;
     }
     
 	public void close() throws IOException {

--- a/src/java/io/compgen/ngsutils/tabix/TabixFile.java
+++ b/src/java/io/compgen/ngsutils/tabix/TabixFile.java
@@ -6,6 +6,7 @@ import java.nio.channels.FileChannel;
 import java.util.Iterator;
 import java.util.zip.DataFormatException;
 
+import io.compgen.ngsutils.support.CachedIterator;
 import io.compgen.common.StringLineReader;
 import io.compgen.ngsutils.annotation.GenomeSpan;
 import io.compgen.ngsutils.support.LogUtils;
@@ -22,6 +23,11 @@ public class TabixFile {
     private boolean removeChr = false;
     
     private boolean closed = false;
+
+    private String lastRef = null;
+    private int lastStart = -1;
+    private int lastEnd = -1;
+    private CachedIterator<String> lastIter = null;
     
 	static public boolean isTabixFile(String filename) {
 		return isTabixFile(filename, false);
@@ -209,7 +215,22 @@ public class TabixFile {
             ref = ref.substring(3);
         }
 
-        return new TabixQueryIterator(ref, start, end, index, bgzf);
+        if (lastIter != null && ref.equals(lastRef) && start == lastStart && end == lastEnd) {
+        	if (!lastIter.isExhausted()) {
+        		while (lastIter.hasNext()) {
+        			lastIter.next();
+        		}
+        	}
+        	lastIter.reset();
+        	return lastIter;
+        }
+        
+        CachedIterator<String> iter = new CachedIterator<String>(new TabixQueryIterator(ref, start, end, index, bgzf));
+        lastRef = ref;
+        lastStart = start;
+        lastEnd = end;
+        lastIter = iter;
+        return iter;
 	}
 
     public Iterator<String> query(GenomeSpan span) throws IOException, DataFormatException {


### PR DESCRIPTION
  - Motivation: speed up vcf-annotate when multiple --vcf annotations hit the same tabix file by reusing the last query results; make BGZF cache size configurable.
  - Changes:
      - Add CachedIterator to memoize tabix query results.
      - Cache last (ref,start,end) query in TabixFile to reuse results across identical queries.
      - Make BGZF block cache default 32 MB and configurable via -Dngsutilsj.bgzf.cache.mb.
      - Document the property in README.
  - Tests: ant compile (run on server).
